### PR TITLE
feat: 팔로우 요청, 수락, 거절, 언팔 API 구현

### DIFF
--- a/src/main/java/com/nbacm/newsfeed/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/controller/FollowController.java
@@ -1,0 +1,41 @@
+package com.nbacm.newsfeed.domain.follow.controller;
+
+import com.nbacm.newsfeed.domain.follow.dto.FollowRequestResponse;
+import com.nbacm.newsfeed.domain.follow.service.FollowService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/follows")
+@RestController
+public class FollowController {
+
+    private final FollowService followService;
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<String> unfollow(@PathVariable Long userId, HttpServletRequest request) {
+        followService.deleteFollow(userId, request);
+        return ResponseEntity.ok("언팔 완료");
+    }
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<FollowRequestResponse> sendFollowRequest(@PathVariable Long userId, HttpServletRequest request) {
+        FollowRequestResponse followRequestResponse = followService.sendFollowRequest(userId, request);
+        return ResponseEntity.ok(followRequestResponse);
+    }
+
+    @PostMapping("/accept/{followRequestId}")
+    public ResponseEntity<FollowRequestResponse> acceptFollowRequest(@PathVariable Long followRequestId, HttpServletRequest request) {
+        FollowRequestResponse followRequestResponse = followService.acceptFollowRequest(followRequestId, request);
+        return ResponseEntity.ok(followRequestResponse);
+    }
+
+    @PostMapping("/reject/{followRequestId}")
+    public ResponseEntity<FollowRequestResponse> rejectFollowRequest(@PathVariable Long followRequestId, HttpServletRequest request) {
+        FollowRequestResponse followRequestResponse = followService.rejectFollowRequest(followRequestId, request);
+        return ResponseEntity.ok(followRequestResponse);
+    }
+
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/dto/FollowRequestResponse.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/dto/FollowRequestResponse.java
@@ -1,0 +1,21 @@
+package com.nbacm.newsfeed.domain.follow.dto;
+
+import com.nbacm.newsfeed.domain.follow.entity.FollowRequest;
+import com.nbacm.newsfeed.domain.follow.entity.FollowRequestStatus;
+import lombok.*;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class FollowRequestResponse {
+    private Long followRequestId;
+    private FollowRequestStatus followRequestStatus;
+
+    public static FollowRequestResponse from(FollowRequest followRequest) {
+        return FollowRequestResponse.builder()
+                .followRequestId(followRequest.getId())
+                .followRequestStatus(followRequest.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/entity/Follow.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/entity/Follow.java
@@ -2,22 +2,30 @@ package com.nbacm.newsfeed.domain.follow.entity;
 
 import com.nbacm.newsfeed.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long followerId;
+    private Long followId;
 
-    private Long followeeId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id")
+    private User follower; // 팔로우를 하는 사용자
 
-    @ManyToOne
-    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id")
+    private User following; // 팔로우를 받는 사용자
 
-
-
+    @Builder
+    private Follow(User following, User follower) {
+        this.following = following;
+        this.follower= follower;
+    }
 }

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/entity/FollowRequest.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/entity/FollowRequest.java
@@ -1,0 +1,46 @@
+package com.nbacm.newsfeed.domain.follow.entity;
+
+import com.nbacm.newsfeed.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class FollowRequest {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private User sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recevier_id")
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    private FollowRequestStatus status;
+
+    @Builder
+    private FollowRequest(User sender, User receiver) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.status = FollowRequestStatus.PENDING;
+    }
+
+    public void accept() {
+        this.status = FollowRequestStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        this.status = FollowRequestStatus.REJECTED;
+    }
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/entity/FollowRequestStatus.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/entity/FollowRequestStatus.java
@@ -1,0 +1,5 @@
+package com.nbacm.newsfeed.domain.follow.entity;
+
+public enum FollowRequestStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,15 @@
+package com.nbacm.newsfeed.domain.follow.repository;
+
+import com.nbacm.newsfeed.domain.follow.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    boolean existsByFollowerUserIdAndFollowingUserId(Long followerId, Long followingId);
+
+    void deleteByFollowerUserIdAndFollowingUserId(Long followerId, Long followingId);
+
+    List<Follow> findByFollowerUserId(Long followerId);
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/repository/FollowRequestRepository.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/repository/FollowRequestRepository.java
@@ -1,0 +1,15 @@
+package com.nbacm.newsfeed.domain.follow.repository;
+
+import com.nbacm.newsfeed.domain.follow.entity.FollowRequest;
+import com.nbacm.newsfeed.domain.follow.entity.FollowRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRequestRepository extends JpaRepository<FollowRequest, Long> {
+    Optional<FollowRequest> findBySenderUserIdAndReceiverUserIdAndStatus(Long senderId, Long receiverId, FollowRequestStatus status);
+
+    // 특정 사용자가 받은 팔로우 요청들 중에서 특정 상태에 있는 것들을 조회할 때 사용
+    List<FollowRequest> findByReceiverUserIdAndStatus(Long receiverId, FollowRequestStatus status);
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/service/FollowService.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/service/FollowService.java
@@ -1,0 +1,111 @@
+package com.nbacm.newsfeed.domain.follow.service;
+
+import com.nbacm.newsfeed.domain.follow.dto.FollowRequestResponse;
+import com.nbacm.newsfeed.domain.follow.entity.Follow;
+import com.nbacm.newsfeed.domain.follow.entity.FollowRequest;
+import com.nbacm.newsfeed.domain.follow.entity.FollowRequestStatus;
+import com.nbacm.newsfeed.domain.follow.repository.FollowRepository;
+import com.nbacm.newsfeed.domain.follow.repository.FollowRequestRepository;
+import com.nbacm.newsfeed.domain.user.entity.User;
+import com.nbacm.newsfeed.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final FollowRequestRepository followRequestRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void saveFollow(Long userId, String email) {
+        User follower = userRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        User following = userRepository.findById(userId).orElseThrow(RuntimeException::new);
+
+        if (followRepository.existsByFollowerUserIdAndFollowingUserId(follower.getUserId(), following.getUserId())) {
+            throw new RuntimeException("이미 팔로우를 누른 사용자입니다.");
+        }
+
+        Follow follow = Follow.builder()
+                .follower(follower)
+                .following(following)
+                .build();
+
+        followRepository.save(follow);
+    }
+
+    @Transactional
+    public void deleteFollow(Long followingId, HttpServletRequest request) {
+        String email = (String) request.getAttribute("AuthenticatedUser");
+        User follower = userRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        User following = userRepository.findById(followingId).orElseThrow(RuntimeException::new);
+
+        followRepository.deleteByFollowerUserIdAndFollowingUserId(follower.getUserId(), following.getUserId());
+    }
+
+    @Transactional
+    public FollowRequestResponse sendFollowRequest(Long receiverId, HttpServletRequest request) {
+        String email = (String) request.getAttribute("AuthenticatedUser");
+        User sender = userRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        User receiver = userRepository.findById(receiverId).orElseThrow(RuntimeException::new);
+
+        if (sender.equals(receiver)) {
+            throw new RuntimeException("자신에게 팔로우 신청을 할 수 없습니다.");
+        }
+
+        if (followRepository.existsByFollowerUserIdAndFollowingUserId(sender.getUserId(), receiver.getUserId())) {
+            throw new RuntimeException("이미 팔로우가 되어있는 사용자입니다.");
+        }
+
+        if (followRequestRepository.findBySenderUserIdAndReceiverUserIdAndStatus(sender.getUserId(), receiver.getUserId(), FollowRequestStatus.PENDING).isPresent()) {
+            throw new RuntimeException("이미 팔로우 신청을 한 사용자입니다.");
+        }
+
+        FollowRequest followRequest = FollowRequest.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .build();
+
+        followRequestRepository.save(followRequest);
+        return FollowRequestResponse.from(followRequest);
+    }
+
+    @Transactional
+    public FollowRequestResponse acceptFollowRequest(Long requestId, HttpServletRequest request) {
+        String email = (String) request.getAttribute("AuthenticatedUser");
+        User receiver = userRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        FollowRequest followRequest = followRequestRepository.findById(requestId).orElseThrow(() -> new RuntimeException("팔로우 신청을 찾을 수 없습니다."));
+
+        if (!followRequest.getReceiver().getUserId().equals(receiver.getUserId())) {
+            throw new RuntimeException("요청을 처리할 권한이 없습니다.");
+        }
+
+        Follow follow = Follow.builder()
+                .follower(followRequest.getSender())
+                .following(followRequest.getReceiver())
+                .build();
+
+        followRequest.accept();
+        followRepository.save(follow);
+        return FollowRequestResponse.from(followRequest);
+    }
+
+    @Transactional
+    public FollowRequestResponse rejectFollowRequest(Long requestId, HttpServletRequest request) {
+        String email = (String) request.getAttribute("AuthenticatedUser");
+        User receiver = userRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        FollowRequest followRequest = followRequestRepository.findById(requestId).orElseThrow(() -> new RuntimeException("팔로우 신청을 찾을 수 없습니다."));
+
+        if (!followRequest.getReceiver().getUserId().equals(receiver.getUserId())) {
+            throw new RuntimeException("요청을 처리할 권한이 없습니다.");
+        }
+
+        followRequest.reject();
+
+        return FollowRequestResponse.from(followRequest);
+    }
+}


### PR DESCRIPTION
* 팔로우 요청, 수락, 거절 API 를 구현했습니다.
* 언팔 API를 구현했습니다.
* 팔로우 요청은 3개의 상태를 가집니다.
  * `PENDING`, `ACCEPTED`, `REJECTED`