### PR TITLE
feat: 예외처리 구현

### DIFF
--- a/src/main/java/com/nbacm/newsfeed/domain/advice/ControllerAdvice.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/advice/ControllerAdvice.java
@@ -1,0 +1,39 @@
+package com.nbacm.newsfeed.domain.advice;
+
+import com.nbacm.newsfeed.domain.exception.BadRequestException;
+import com.nbacm.newsfeed.domain.exception.ForbiddenException;
+import com.nbacm.newsfeed.domain.exception.NotFoundException;
+import com.nbacm.newsfeed.domain.exception.UnauthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    @ExceptionHandler(NotFoundException.class) // 404 Not Found
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(BadRequestException.class) // 400 Bad Request
+    public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException e) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class) // 403 Forbidden
+    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class) // 401 Unauthorized
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(RuntimeException.class) // 500 Internal Server Error
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+        return ResponseEntity.internalServerError().body(new ErrorResponse("서버에 알 수 없는 문제가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/advice/ErrorResponse.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/advice/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.nbacm.newsfeed.domain.advice;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private final String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/exception/BadRequestException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/exception/BadRequestException.java
@@ -1,0 +1,5 @@
+package com.nbacm.newsfeed.domain.exception;
+
+public class BadRequestException extends RuntimeException{
+    public BadRequestException(String message) {super(message);}
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/exception/ForbiddenException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/exception/ForbiddenException.java
@@ -1,0 +1,5 @@
+package com.nbacm.newsfeed.domain.exception;
+
+public class ForbiddenException extends RuntimeException{
+    public ForbiddenException(String message) {super(message);}
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/exception/NotFoundException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/exception/NotFoundException.java
@@ -1,0 +1,5 @@
+package com.nbacm.newsfeed.domain.exception;
+
+public class NotFoundException extends RuntimeException{
+    public NotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/exception/UnauthorizedException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/exception/UnauthorizedException.java
@@ -1,0 +1,5 @@
+package com.nbacm.newsfeed.domain.exception;
+
+public class UnauthorizedException extends RuntimeException{
+    public UnauthorizedException(String message) {super(message);}
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/exception/AlreadyFollowedException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/exception/AlreadyFollowedException.java
@@ -1,0 +1,12 @@
+package com.nbacm.newsfeed.domain.follow.exception;
+
+import com.nbacm.newsfeed.domain.exception.BadRequestException;
+
+public class AlreadyFollowedException extends BadRequestException {
+
+    private static final String MESSAGE = "이미 팔로우가 되어있습니다";
+
+    public AlreadyFollowedException() {super(MESSAGE);}
+
+    public AlreadyFollowedException(String message) {super(message);}
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/exception/DuplicateFollowRequestException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/exception/DuplicateFollowRequestException.java
@@ -1,0 +1,13 @@
+package com.nbacm.newsfeed.domain.follow.exception;
+
+import com.nbacm.newsfeed.domain.exception.BadRequestException;
+
+public class DuplicateFollowRequestException extends BadRequestException {
+
+    private static final String MESSAGE = "중복된 팔로우 신청입니다.";
+
+    public DuplicateFollowRequestException() {super(MESSAGE);}
+
+    public DuplicateFollowRequestException(String message) {super(message);}
+}
+

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/exception/FollowRequestNotFoundException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/exception/FollowRequestNotFoundException.java
@@ -1,0 +1,12 @@
+package com.nbacm.newsfeed.domain.follow.exception;
+
+import com.nbacm.newsfeed.domain.exception.NotFoundException;
+
+public class FollowRequestNotFoundException extends NotFoundException {
+
+    private static final String MESSAGE = "해당 팔로우 신청을 찾을 수 없습니다.";
+
+    public FollowRequestNotFoundException() {super(MESSAGE);}
+
+    public FollowRequestNotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/exception/SelfFollowException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/exception/SelfFollowException.java
@@ -1,0 +1,12 @@
+package com.nbacm.newsfeed.domain.follow.exception;
+
+import com.nbacm.newsfeed.domain.exception.BadRequestException;
+
+public class SelfFollowException extends BadRequestException {
+
+    private static final String MESSAGE = "자신에게 팔로우 신청을 할 수 없습니다..";
+
+    public SelfFollowException() {super(MESSAGE);}
+
+    public SelfFollowException(String message) {super(message);}
+}

--- a/src/main/java/com/nbacm/newsfeed/domain/follow/exception/UnauthorizedFollowRequestException.java
+++ b/src/main/java/com/nbacm/newsfeed/domain/follow/exception/UnauthorizedFollowRequestException.java
@@ -1,0 +1,12 @@
+package com.nbacm.newsfeed.domain.follow.exception;
+
+import com.nbacm.newsfeed.domain.exception.UnauthorizedException;
+
+public class UnauthorizedFollowRequestException extends UnauthorizedException {
+
+    private static final String MESSAGE = "권한이 없습니다.";
+
+    public UnauthorizedFollowRequestException() {super(MESSAGE);}
+
+    public UnauthorizedFollowRequestException(String message) {super(message);}
+}


### PR DESCRIPTION
`RestControllerAdvice` 를 이용하여 예외처리를 구현했습니다.

각 엔티티에 맞는 예외를 구현하실 때에 `domain/exception` 아래에 있는 예외중에서 
반환할 상태코드를 확인하시고 상속받으신 후에 구현하시면 됩니다.

* 400 Bad Request : `BadRequestException`
* 401 Unauthorized : `UnauthorizedException`
* 403 Forbidden : `ForbiddenException`
* 404 Not Found : `NotFoundException`
* 500 Internal Server Error : `RuntimeException`